### PR TITLE
reverting pr#8

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,65 +66,17 @@ function randomatic(pattern, length, options) {
   var mask = '';
   var res = '';
 
-  var setupCounter = 0;
-  var setup = [];
   // Characters to be used
-  if (pattern.indexOf('?') !== -1) {
-    setup[setupCounter++] = {
-      chars: opts.chars
-    };
-  }
-  if (pattern.indexOf('a') !== -1) {
-    setup[setupCounter++] = {
-      chars: type.lower
-    };
-  }
-  if (pattern.indexOf('A') !== -1) {
-    setup[setupCounter++] = {
-      chars: type.upper
-    };
-  }
-  if (pattern.indexOf('0') !== -1) {
-    setup[setupCounter++] = {
-      chars: type.number
-    };
-  }
-  if (pattern.indexOf('!') !== -1) {
-    setup[setupCounter++] = {
-      chars: type.special
-    };
-  }
-  if (pattern.indexOf('*') !== -1) {
-    setup[setupCounter++] = {
-      chars: type.lower
-    };
-    setup[setupCounter++] = {
-      chars: type.upper
-    };
-    setup[setupCounter++] = {
-      chars: type.number
-    };
-    setup[setupCounter++] = {
-      chars: type.special
-    };
-  }
-  if (custom) {
-    setup[setupCounter++] = {
-      chars: pattern
-    };
-  };
+  if (pattern.indexOf('?') !== -1) mask += opts.chars;
+  if (pattern.indexOf('a') !== -1) mask += type.lower;
+  if (pattern.indexOf('A') !== -1) mask += type.upper;
+  if (pattern.indexOf('0') !== -1) mask += type.number;
+  if (pattern.indexOf('!') !== -1) mask += type.special;
+  if (pattern.indexOf('*') !== -1) mask += type.all;
+  if (custom) mask += pattern;
 
-  setupCounter = 0;
   while (length--) {
-    if(!setup[setupCounter]) {
-      setupCounter = 0;
-    }
-    var obj = setup[setupCounter++];
-    res += obj.chars.charAt(getRandomInt(0, obj.chars.length - 1));
+    res += mask.charAt(parseInt(Math.random() * mask.length, 10));
   }
   return res;
 };
-
-function getRandomInt(min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}

--- a/test.js
+++ b/test.js
@@ -94,14 +94,6 @@ describe('randomatic', function() {
     randomize('*', 16).length.should.equal(16);
   });
 
-  it('should generate Alpha (Upper/Lower), Numeric, Special Char 16-character string', function() {
-    var actual = randomize('*');
-    test(/^(?=.*[~!@#$%^&()_+-={}[\];\',.]).*$/, actual).should.be.true;
-    test(/^(?=.*[A-Z]).*$/, actual).should.be.true;
-    test(/^(?=.*[a-z]).*$/, actual).should.be.true;
-    test(/(?=.*\d).*$/, actual).should.be.true;
-  });
-
   it('alphabetical, 10 digit:', function() {
     randomize('A', 10).length.should.equal(10);
   });


### PR DESCRIPTION
After reviewing locally, the logic is incorrect. This forces `a-z` to be used on `*`, and more importantly I think this makes the result "less random". 