### PR TITLE
Fix Issue #18 : Exclude not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,10 @@ function randomatic(pattern, length, options) {
   // Characters to exclude
   if (opts.exclude) {
     var exclude = typeOf(opts.exclude) === 'string' ? opts.exclude : opts.exclude.join('');
+    exclude = exclude.replace(new RegExp('[\\]]+', 'g'), '');
     mask = mask.replace(new RegExp('[' + exclude + ']+', 'g'), '');
+    
+    if(opts.exclude.indexOf(']') !== -1) mask = mask.replace(new RegExp('[\\]]+', 'g'), '');
   }
 
   while (length--) {

--- a/test.js
+++ b/test.js
@@ -103,6 +103,18 @@ describe('randomatic', function() {
     assert.equal(actual.length, 16);
   });
 
+  it('should generate a random string excluding right square bracket on the `exclude` option', function() {
+    var actual = randomize('*', 16, {exclude: ']'});
+    assert(test(/[^\]]{16}/, actual));
+    assert.equal(actual.length, 16);
+  });
+
+  it('should generate a random string excluding array with one element(right square bracket) on the `exclude` option', function() {
+    var actual = randomize('*', 16, {exclude: [']']});
+    assert(test(/[^\]]{16}/, actual));
+    assert.equal(actual.length, 16);
+  });
+
   it('should generate a radomized 16-character string', function() {
     assert.equal(randomize('*', 16).length, 16);
   });


### PR DESCRIPTION
The issue is that if exclude option has right square bracket, the regular expression pattern breaks, and it does not exclude any characters user input.

I added few lines of code to handle right square bracket. I also added two test cases when exclude option has right square bracket character.

Let me know if I need to adjust the code.
Thanks.